### PR TITLE
Optimize parsing by compiling regular expressions once

### DIFF
--- a/Sources/UAParserSwift/UAParserSwift.swift
+++ b/Sources/UAParserSwift/UAParserSwift.swift
@@ -137,7 +137,7 @@ public class UAParser {
 internal struct Rule {
 	
 	/// Set of regular expressions which can validate the rule
-	public private(set) var regexp: [String]
+	public private(set) var regexp: [NSRegularExpression]
 	
 	/// Function to execute to parse given regexp results in a valid dictionary
 	public private(set) var funcs: [Funcs]
@@ -148,7 +148,10 @@ internal struct Rule {
 	///   - regexp: regular expressions
 	///   - funcs: function to parse matched regular expression substrings
 	public init(_ regexp: [String], _ funcs: [Funcs]) {
-		self.regexp = regexp
+		self.regexp = regexp.map { (regex) in
+			try! NSRegularExpression(pattern: regex, options: [.caseInsensitive])
+		}
+
 		self.funcs = funcs
 	}
 	
@@ -861,10 +864,7 @@ public extension String {
 	///
 	/// - Parameter regex: regular express used to filter
 	/// - Returns: matching strings
-	func matchingStrings(regex: String) -> [String]? {
-		guard let regex = try? NSRegularExpression(pattern: regex, options: [.caseInsensitive]) else {
-			return nil
-		}
+	func matchingStrings(regex: NSRegularExpression) -> [String]? {
 		let nsString = NSString(string: self)
 		let results  = regex.matches(in: self, options: [], range: NSMakeRange(0, nsString.length))
 		let matches = results.map { result in

--- a/Sources/UAParserSwift/UAParserSwift.swift
+++ b/Sources/UAParserSwift/UAParserSwift.swift
@@ -865,7 +865,7 @@ public extension String {
 		guard let regex = try? NSRegularExpression(pattern: regex, options: [.caseInsensitive]) else {
 			return nil
 		}
-		let nsString = self as NSString
+		let nsString = NSString(string: self)
 		let results  = regex.matches(in: self, options: [], range: NSMakeRange(0, nsString.length))
 		let matches = results.map { result in
 			(0..<result.numberOfRanges).map { result.range(at: $0).location != NSNotFound

--- a/Tests/UAParserSwiftTests/UAParserSwift_Tests.swift
+++ b/Tests/UAParserSwiftTests/UAParserSwift_Tests.swift
@@ -27,7 +27,7 @@ class UAParserSwiftTests: XCTestCase {
 			let decoder = JSONDecoder()
 			let data = try decoder.decode([TestItem].self, from: jsonData)
 			return data
-		} catch let err {
+		} catch {
 			return nil
 		}
 	}
@@ -135,6 +135,10 @@ class UAParserSwiftTests: XCTestCase {
 	}
     
     static var allTests = [
-        ("tests", test_cpu,test_engines,test_os,test_device,test_browser),
+        ("test_cpu", test_cpu),
+        ("test_engines", test_engines),
+        ("test_os", test_os),
+        ("test_device", test_device),
+        ("test_browser", test_browser),
     ]
 }


### PR DESCRIPTION
I have troubled with this library when I parse 100 user-agent strings at once.

`Rule` has regex source string and compiles it for every matching.
Compiling large regex such like used in this library is very heavy operation.

It changes `Rule` to have compiled regex rather than source string.
So if we test many strings, it can reuse compiled regex and improve performance.

In my case, in situation which takes over 6000msec originally,
it reduced to under 150msec.